### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Test
 
 on:
@@ -30,5 +32,4 @@ jobs:
       - run: npm ci --prefer-offline --no-audit --no-fund
       - run: npm run build
       - run:
-          node --import tsx --test --test-shard=${{ matrix.shard }}
-          src/__tests__/unit/**/*.test.ts src/__tests__/unit/*.test.ts
+          node --import tsx --test --test-shard=${{ matrix


### PR DESCRIPTION
Potential fix for [https://github.com/great-detail/WhatsApp-Nodejs-SDK/security/code-scanning/3](https://github.com/great-detail/WhatsApp-Nodejs-SDK/security/code-scanning/3)

To address the issue, we need to add a `permissions` block to the workflow file. This block should specify the minimum permissions required for the tasks in the workflow. Since the workflow primarily involves checking out code and running tests, `contents: read` is appropriate, as it allows read access to the repository contents without granting write access or additional permissions.

The `permissions` block can be added at the root level of the workflow (applying to all jobs) or within the specific job (`build_and_test`). In this case, we'll add it at the root level to ensure consistent permissions across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
